### PR TITLE
Make units optional

### DIFF
--- a/resources/properties/properties.xml
+++ b/resources/properties/properties.xml
@@ -1,0 +1,11 @@
+<resources>
+    <properties>
+        <property id="displayUnits" type="boolean">false</property>
+    </properties>
+
+    <settings>
+        <setting propertyKey="@Properties.displayUnits" title="@Strings.displayUnits">
+            <settingConfig type="boolean" />
+        </setting>
+    </settings>
+</resources>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -2,4 +2,5 @@
     <string id="AppName">BackAtDaylight</string>
 
     <string id="label">ø spd. Sunset</string>
+    <string id="displayUnits">Display Units</string>
 </strings>

--- a/source/BackAtDaylightView.mc
+++ b/source/BackAtDaylightView.mc
@@ -46,7 +46,7 @@ class BackAtDaylightView extends WatchUi.SimpleDataField  {
     }
 
     function compute(info) {
-        var speedNeeded = displayUnits ? "__._" + unit : "-/-";
+        var speedNeeded = "No data";
 
         if(info has :distanceToDestination and info has :currentLocation) {
             if(info.distanceToDestination != null and info.currentLocation != null) {

--- a/source/BackAtDaylightView.mc
+++ b/source/BackAtDaylightView.mc
@@ -18,6 +18,7 @@ using Toybox.Math;
 using Toybox.WatchUi;
 using Toybox.Time;
 using Toybox.System;
+using Toybox.Application;
 
 class BackAtDaylightView extends WatchUi.SimpleDataField  {
 
@@ -33,7 +34,7 @@ class BackAtDaylightView extends WatchUi.SimpleDataField  {
 
     function initialize() {
         SimpleDataField.initialize();
-        app = App.getApp();
+        app = Application.getApp();
         label = loadResource(Rez.Strings.label);
 
         var distanceUnits = System.getDeviceSettings().distanceUnits;

--- a/source/BackAtDaylightView.mc
+++ b/source/BackAtDaylightView.mc
@@ -28,13 +28,13 @@ class BackAtDaylightView extends WatchUi.SimpleDataField  {
     const FRAC_JULIAN_DAY = 0.0008;
     const STATUTE_UNIT_FACTOR = 1.609344;
 
-    hidden var app;
+    hidden var displayUnits;
     hidden var unit = " kph";
     hidden var adjustment = 1000;
 
     function initialize() {
         SimpleDataField.initialize();
-        app = Application.getApp();
+        displayUnits = Application.getApp().getProperty("displayUnits");
         label = loadResource(Rez.Strings.label);
 
         var distanceUnits = System.getDeviceSettings().distanceUnits;
@@ -46,7 +46,6 @@ class BackAtDaylightView extends WatchUi.SimpleDataField  {
     }
 
     function compute(info) {
-        var displayUnits = app.getProperty("displayUnits");
         var speedNeeded = displayUnits ? "__._" + unit : "-/-";
 
         if(info has :distanceToDestination and info has :currentLocation) {

--- a/source/BackAtDaylightView.mc
+++ b/source/BackAtDaylightView.mc
@@ -47,7 +47,7 @@ class BackAtDaylightView extends WatchUi.SimpleDataField  {
 
     function compute(info) {
         var displayUnits = app.getProperty("displayUnits");
-        var speedNeeded = displayUnits ? "__._" + unit : "__._";
+        var speedNeeded = displayUnits ? "__._" + unit : "-/-";
 
         if(info has :distanceToDestination and info has :currentLocation) {
             if(info.distanceToDestination != null and info.currentLocation != null) {
@@ -63,7 +63,7 @@ class BackAtDaylightView extends WatchUi.SimpleDataField  {
                     
                     var result = distanceLeft / hoursLeft;
 
-                    speedNeeded = displayUnits ? result.format("%3.2f") + unit : result;
+                    speedNeeded = displayUnits ? result.format("%3.2f") + unit : result.format("%3.2f");
  
                 } else {
                     speedNeeded = "Lightspeed";

--- a/source/BackAtDaylightView.mc
+++ b/source/BackAtDaylightView.mc
@@ -46,7 +46,8 @@ class BackAtDaylightView extends WatchUi.SimpleDataField  {
     }
 
     function compute(info) {
-        var speedNeeded = "_.__" + unit;
+        var displayUnits = app.getProperty("displayUnits");
+        var speedNeeded = displayUnits ? "__._" + unit : "__._";
 
         if(info has :distanceToDestination and info has :currentLocation) {
             if(info.distanceToDestination != null and info.currentLocation != null) {
@@ -62,12 +63,8 @@ class BackAtDaylightView extends WatchUi.SimpleDataField  {
                     
                     var result = distanceLeft / hoursLeft;
 
-                    if(app.getProperty("displayUnits")) {
-                        speedNeeded = result.format("%3.2f") + unit;
-                    } else {
-                        speedNeeded = result;
-                    }
-
+                    speedNeeded = displayUnits ? result.format("%3.2f") + unit : result;
+ 
                 } else {
                     speedNeeded = "Lightspeed";
                 }

--- a/source/BackAtDaylightView.mc
+++ b/source/BackAtDaylightView.mc
@@ -27,11 +27,13 @@ class BackAtDaylightView extends WatchUi.SimpleDataField  {
     const FRAC_JULIAN_DAY = 0.0008;
     const STATUTE_UNIT_FACTOR = 1.609344;
 
+    hidden var app;
     hidden var unit = " kph";
     hidden var adjustment = 1000;
 
     function initialize() {
         SimpleDataField.initialize();
+        app = App.getApp();
         label = loadResource(Rez.Strings.label);
 
         var distanceUnits = System.getDeviceSettings().distanceUnits;
@@ -58,7 +60,13 @@ class BackAtDaylightView extends WatchUi.SimpleDataField  {
                     var hoursLeft = timeLeft.value().toDouble() / Time.Gregorian.SECONDS_PER_HOUR;
                     
                     var result = distanceLeft / hoursLeft;
-                    speedNeeded = result.format("%3.2f") + unit;
+
+                    if(app.getProperty("displayUnits")) {
+                        speedNeeded = result.format("%3.2f") + unit;
+                    } else {
+                        speedNeeded = result;
+                    }
+
                 } else {
                     speedNeeded = "Lightspeed";
                 }


### PR DESCRIPTION
This PR adds a setting to the data field making the displaying of units optional. The default is to not display the units as they are in line with the units of other data fields anyways.

Resolves #15 if units are hidden.